### PR TITLE
Add default case to cover.sh

### DIFF
--- a/cover.sh
+++ b/cover.sh
@@ -86,5 +86,8 @@ case $ReturnCode in
 	3)
 		echo "Some tests are not even passing! You should fix them NOW before anything committed!"
 		;;
+	*)		
+		echo "Unexpected exit code $ReturnCode!"
+		;;
 esac
 exit $ReturnCode


### PR DESCRIPTION
To resolve critical vulnerability reported because of missing default case in cover.sh.